### PR TITLE
Add secure notes and hidden chat unlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "expo-image-picker": "~16.1.4",
     "expo-notifications": "~0.31.4",
     "expo-status-bar": "~2.2.3",
+    "expo-local-authentication": "~13.7.0",
+    "expo-secure-store": "~13.0.3",
     "firebase": "^12.0.0",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",

--- a/src/contexts/UnlockContext.js
+++ b/src/contexts/UnlockContext.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+import React, { useMemo, useState, createContext } from 'react';
+
+export const UnlockContext = createContext({});
+
+export const UnlockProvider = ({ children }) => {
+  const [unlocked, setUnlocked] = useState(false);
+  const value = useMemo(() => ({ unlocked, setUnlocked }), [unlocked]);
+
+  return <UnlockContext.Provider value={value}>{children}</UnlockContext.Provider>;
+};
+
+UnlockProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/screens/NoteEditor.tsx
+++ b/src/screens/NoteEditor.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable react/prop-types */
+import * as SecureStore from 'expo-secure-store';
+import { View, Button, TextInput } from 'react-native';
+import React, { useState, useEffect, useContext } from 'react';
+import * as LocalAuthentication from 'expo-local-authentication';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { UnlockContext } from '../contexts/UnlockContext';
+
+const NOTES_KEY = 'notes';
+
+const NoteEditor = ({ route, navigation }) => {
+  const { id } = route.params || {};
+  const [text, setText] = useState('');
+  const [phrase, setPhrase] = useState('');
+  const [triggered, setTriggered] = useState(false);
+  const { setUnlocked } = useContext(UnlockContext);
+
+  useEffect(() => {
+    const load = async () => {
+      const json = await AsyncStorage.getItem(NOTES_KEY);
+      const notes = json ? JSON.parse(json) : [];
+      const note = notes.find((n) => n.id === id);
+      if (note) setText(note.text);
+
+      let stored = await SecureStore.getItemAsync('unlock_phrase');
+      if (!stored) {
+        stored = 'open sesame';
+        await SecureStore.setItemAsync('unlock_phrase', stored);
+      }
+      setPhrase(stored);
+    };
+    load();
+  }, [id]);
+
+  useEffect(() => {
+    if (phrase && text.includes(phrase) && !triggered) {
+      setTriggered(true);
+      attemptUnlock();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, phrase, triggered]);
+
+  const save = async () => {
+    const json = await AsyncStorage.getItem(NOTES_KEY);
+    const notes = json ? JSON.parse(json) : [];
+    const newNote = { id: id || Date.now().toString(), text };
+    const index = notes.findIndex((n) => n.id === newNote.id);
+    if (index > -1) {
+      notes[index] = newNote;
+    } else {
+      notes.push(newNote);
+    }
+    await AsyncStorage.setItem(NOTES_KEY, JSON.stringify(notes));
+    navigation.goBack();
+  };
+
+  const attemptUnlock = async () => {
+    const result = await LocalAuthentication.authenticateAsync();
+    if (result.success) {
+      setUnlocked(true);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput
+        multiline
+        style={{ flex: 1, textAlignVertical: 'top' }}
+        value={text}
+        onChangeText={setText}
+      />
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+};
+
+export default NoteEditor;

--- a/src/screens/NotesList.tsx
+++ b/src/screens/NotesList.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable react/prop-types */
+import * as LocalAuthentication from 'expo-local-authentication';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Text, View, Button, FlatList, TouchableOpacity } from 'react-native';
+import React, { useRef, useState, useEffect, useContext, useLayoutEffect } from 'react';
+
+import { UnlockContext } from '../contexts/UnlockContext';
+
+const NOTES_KEY = 'notes';
+
+const NotesList = ({ navigation }) => {
+  const [notes, setNotes] = useState([]);
+  const { setUnlocked } = useContext(UnlockContext);
+  const tapCount = useRef(0);
+  const timer = useRef(null);
+
+  const loadNotes = async () => {
+    const json = await AsyncStorage.getItem(NOTES_KEY);
+    setNotes(json ? JSON.parse(json) : []);
+  };
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', loadNotes);
+    return unsubscribe;
+  }, [navigation]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: () => (
+        <TouchableOpacity onPress={handleHeaderTap}>
+          <Text>Notes</Text>
+        </TouchableOpacity>
+      ),
+      headerRight: () => (
+        <Button title="Add" onPress={() => navigation.navigate('NoteEditor')} />
+      ),
+    });
+  });
+
+  const handleHeaderTap = () => {
+    tapCount.current += 1;
+    if (tapCount.current === 1) {
+      timer.current = setTimeout(() => {
+        tapCount.current = 0;
+      }, 3000);
+    }
+    if (tapCount.current >= 5) {
+      if (timer.current) clearTimeout(timer.current);
+      tapCount.current = 0;
+      attemptUnlock();
+    }
+  };
+
+  const attemptUnlock = async () => {
+    const result = await LocalAuthentication.authenticateAsync();
+    if (result.success) {
+      setUnlocked(true);
+    }
+  };
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity
+      style={{ padding: 16, borderBottomWidth: 1, borderColor: '#ddd' }}
+      onPress={() => navigation.navigate('NoteEditor', { id: item.id })}
+    >
+      <Text numberOfLines={1}>{item.text}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList
+        data={notes}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={<Text style={{ padding: 16 }}>No notes</Text>}
+      />
+    </View>
+  );
+};
+
+export default NotesList;


### PR DESCRIPTION
## Summary
- add NotesList and NoteEditor screens for local note storage with hidden unlock phrase
- secure unlock using expo-secure-store and biometric/PIN auth before switching to chats
- provide quick hide button across chat screens and integrate notes stack

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aec20cc1b083248d3a31a32e108fe9