### PR TITLE
Introduce default notes stack and gated chat access

### DIFF
--- a/src/screens/NoteEditor.tsx
+++ b/src/screens/NoteEditor.tsx
@@ -2,11 +2,8 @@
 /* eslint-disable react/prop-types */
 import * as SecureStore from 'expo-secure-store';
 import { View, Button, TextInput } from 'react-native';
-import React, { useState, useEffect, useContext } from 'react';
-import * as LocalAuthentication from 'expo-local-authentication';
+import React, { useState, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-
-import { UnlockContext } from '../contexts/UnlockContext';
 
 const NOTES_KEY = 'notes';
 
@@ -15,7 +12,6 @@ const NoteEditor = ({ route, navigation }) => {
   const [text, setText] = useState('');
   const [phrase, setPhrase] = useState('');
   const [triggered, setTriggered] = useState(false);
-  const { setUnlocked } = useContext(UnlockContext);
 
   useEffect(() => {
     const load = async () => {
@@ -56,11 +52,8 @@ const NoteEditor = ({ route, navigation }) => {
     navigation.goBack();
   };
 
-  const attemptUnlock = async () => {
-    const result = await LocalAuthentication.authenticateAsync();
-    if (result.success) {
-      setUnlocked(true);
-    }
+  const attemptUnlock = () => {
+    navigation.navigate('Unlock');
   };
 
   return (

--- a/src/screens/NotesList.tsx
+++ b/src/screens/NotesList.tsx
@@ -1,17 +1,13 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable react/prop-types */
-import * as LocalAuthentication from 'expo-local-authentication';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Text, View, Button, FlatList, TouchableOpacity } from 'react-native';
-import React, { useRef, useState, useEffect, useContext, useLayoutEffect } from 'react';
-
-import { UnlockContext } from '../contexts/UnlockContext';
+import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
 
 const NOTES_KEY = 'notes';
 
 const NotesList = ({ navigation }) => {
   const [notes, setNotes] = useState([]);
-  const { setUnlocked } = useContext(UnlockContext);
   const tapCount = useRef(0);
   const timer = useRef(null);
 
@@ -52,11 +48,8 @@ const NotesList = ({ navigation }) => {
     }
   };
 
-  const attemptUnlock = async () => {
-    const result = await LocalAuthentication.authenticateAsync();
-    if (result.success) {
-      setUnlocked(true);
-    }
+  const attemptUnlock = () => {
+    navigation.navigate('Unlock');
   };
 
   const renderItem = ({ item }) => (

--- a/src/screens/Unlock.js
+++ b/src/screens/Unlock.js
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable react/prop-types */
+import * as LocalAuthentication from 'expo-local-authentication';
+import React, { useContext, useEffect } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+
+import { UnlockContext } from '../contexts/UnlockContext';
+import { AuthenticatedUserContext } from '../contexts/AuthenticatedUserContext';
+
+const Unlock = ({ navigation }) => {
+  const { setUnlocked } = useContext(UnlockContext);
+  const { user } = useContext(AuthenticatedUserContext);
+
+  useEffect(() => {
+    const authenticate = async () => {
+      const result = await LocalAuthentication.authenticateAsync();
+      if (result.success) {
+        setUnlocked(true);
+        navigation.reset({
+          index: 0,
+          routes: [{ name: user ? 'Chat' : 'Auth' }],
+        });
+      } else {
+        navigation.reset({ index: 0, routes: [{ name: 'Notes' }] });
+      }
+    };
+    authenticate();
+  }, [navigation, setUnlocked, user]);
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+};
+
+export default Unlock;


### PR DESCRIPTION
## Summary
- Add Unlock screen with biometric authentication to gate chat access and sign-in
- Make Notes stack the default navigation and hide chat screens in a dedicated ChatStack
- Quick Hide now resets navigation back to Notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aec426d3588324a63f916677b91048