### PR TITLE
feat: add firestore and storage rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,35 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isConversationMember(cid) {
+      return request.auth != null &&
+        request.auth.uid in get(/databases/$(database)/documents/conversations/$(cid)).data.members;
+    }
+
+    function isCallParticipant(callId) {
+      return request.auth != null &&
+        let call = get(/databases/$(database)/documents/calls/$(callId)).data;
+        call.from == request.auth.uid || call.to == request.auth.uid;
+    }
+
+    match /conversations/{cid} {
+      match /messages/{mid} {
+        allow read, write: if isConversationMember(cid);
+      }
+    }
+
+    match /calls/{callId} {
+      allow read, write: if isCallParticipant(callId);
+      match /{document=**} {
+        allow read, write: if isCallParticipant(callId);
+      }
+    }
+
+    match /users/{uid} {
+      allow read: if resource.data.keys().hasOnly(['displayName', 'photoURL']);
+      allow write: if request.auth != null &&
+        request.auth.uid == uid &&
+        request.resource.data.keys().hasOnly(['displayName', 'photoURL']);
+    }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isConversationMember(cid) {
+      return request.auth != null &&
+        request.auth.uid in firestore.get(/databases/(default)/documents/conversations/$(cid)).data.members;
+    }
+
+    match /conversations/{cid}/media/{allPaths=**} {
+      allow read, write: if isConversationMember(cid);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore rules for conversations, calls, and limited user fields
- add Storage rules restricting media access to conversation members

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68aed0f0d8fc8324aae753488a1df176